### PR TITLE
Add dependency for SageMaker build job in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,7 @@ jobs:
 
   # ─── Build & Push SageMaker ARM64 Image (for SageMaker endpoint) ────
   build-push-sagemaker:
+    needs: [build-push-backend]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
- Updated the deploy.yml file to ensure the build-push-sagemaker job depends on the build-push-backend job, improving the workflow execution order and ensuring necessary prerequisites are met before building the SageMaker image.