### PR TITLE
Enhance Docker workflows for ARM64 builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,43 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ─── Build features-engine Rust wheel (shared across images) ──────
+  build-features-engine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU for ARM64 emulation
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build features-engine ARM64 wheel
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            -f backend/Dockerfile \
+            --target rust-builder \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --output type=tar,dest=/tmp/wheels.tar \
+            backend/
+          mkdir -p wheels/wheels
+          tar -xf /tmp/wheels.tar -C /tmp/wheel-extract
+          cp /tmp/wheel-extract/wheels/features_engine*.whl wheels/wheels/
+          ls -la wheels/wheels/
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: features-engine-wheel
+          path: wheels/
+          retention-days: 1
+
   # ─── Build & Push ARM64 Backend Image (for ECS) ───────────────────
   build-push-backend:
+    needs: [build-features-engine]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -47,6 +82,12 @@ jobs:
         # ADR 009: QEMU required for linux/arm64 builds on x86 runners
         uses: docker/setup-qemu-action@v3
 
+      - name: Download pre-built features-engine wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: features-engine-wheel
+          path: wheels
+
       - name: Build and push ARM64 backend image
         uses: docker/build-push-action@v5
         with:
@@ -54,6 +95,8 @@ jobs:
           file: backend/Dockerfile
           platforms: linux/arm64
           push: true
+          build-contexts: |
+            wheel-source=${{ github.workspace }}/wheels
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
@@ -62,6 +105,7 @@ jobs:
 
   # ─── Build & Push Airflow ARM64 Image ────────────────────────────
   build-push-airflow:
+    needs: [build-features-engine]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -82,6 +126,12 @@ jobs:
       - name: Set up QEMU for ARM64 emulation
         uses: docker/setup-qemu-action@v3
 
+      - name: Download pre-built features-engine wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: features-engine-wheel
+          path: wheels
+
       - name: Build and push Airflow ARM64 image
         uses: docker/build-push-action@v5
         with:
@@ -89,6 +139,8 @@ jobs:
           file: airflow/Dockerfile
           platforms: linux/arm64
           push: true
+          build-contexts: |
+            wheel-source=${{ github.workspace }}/wheels
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:airflow-${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:airflow-latest

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -31,6 +31,10 @@ WORKDIR /src
 COPY backend/ml/features-engine /src
 RUN maturin build --release --features extension --out /wheels
 
+# CI override: --build-context wheel-source=<path> provides pre-built wheel,
+# skipping the rust-builder stage entirely (saves ~5min under QEMU).
+FROM rust-builder AS wheel-source
+
 
 # Stage 1: Final Airflow image
 FROM python:3.12-slim
@@ -70,7 +74,7 @@ RUN pip install --no-cache-dir \
     alembic>=1.15.0
 
 # Install Rust native module (features_engine)
-COPY --from=rust-builder /wheels /wheels
+COPY --from=wheel-source /wheels /wheels
 RUN pip install --no-deps /wheels/features_engine*.whl
 
 # Copy DAGs, migration helpers, and config

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,6 +50,10 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     maturin build --release --features extension --out /wheels
 
 
+# CI override: --build-context wheel-source=<path> provides pre-built wheel,
+# skipping the rust-builder stage entirely (saves ~5min under QEMU).
+FROM rust-builder AS wheel-source
+
 # Stage 1: Python deps via uv.
 # uv's cache mount avoids re-downloading 162 deps (~700MB incl. torch/pyarrow)
 # on every build. We deliberately DROP UV_COMPILE_BYTECODE here — bytecode
@@ -64,7 +68,7 @@ COPY pyproject.toml uv.lock ./
 
 # Install Rust native module into the venv, copy wheel aside for re-install
 # in dev/test workflows.
-COPY --from=rust-builder /wheels /wheels
+COPY --from=wheel-source /wheels /wheels
 RUN uv pip install --no-deps --python /usr/local/bin/python3 /wheels/features_engine*.whl && \
     mkdir -p /app/wheels && \
     cp /wheels/features_engine*.whl /app/wheels/

--- a/backend/ml/Dockerfile
+++ b/backend/ml/Dockerfile
@@ -37,6 +37,7 @@ RUN --mount=type=cache,target=/src/target,sharing=locked \
     --mount=type=cache,target=/root/.cargo/registry \
     maturin build --release --features extension --out /wheels
 
+
 # Stage 2: Build Python dependencies with uv
 FROM python:3.14-slim AS builder
 


### PR DESCRIPTION
- Added a new job to build the features-engine Rust wheel for ARM64 architecture, improving build efficiency.
- Updated backend and Airflow Dockerfiles to utilize pre-built wheels, reducing build time by skipping the Rust compilation stage.
- Integrated artifact upload and download steps in the deploy workflow to streamline the build process for ARM64 images.