### PR TITLE
Enhance IAM policies and deploy workflow for SageMaker integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -310,6 +310,7 @@ jobs:
             -var="airflow_image=${AIRFLOW_IMAGE_TAG}" \
             -var="ml_training_image=${ML_TRAINING_IMAGE_TAG}" \
             -var="sagemaker_image=${SAGEMAKER_IMAGE_TAG}" \
+            -var="champion_s3_uri=s3://stocklens-mlflow-artifacts-dev/champion" \
             -var="environment=dev" \
             -out=tfplan || { rc=$?; [ $rc -eq 2 ] && true || exit $rc; }
         working-directory: ${{ env.TERRAFORM_DIR }}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -479,6 +479,7 @@ resource "aws_iam_role_policy" "github_deploy" {
           "elasticache:*", "rds:*", "application-autoscaling:*", "logs:*",
           "elasticloadbalancing:*", "lambda:*",
           "ec2:*", "ssm:*", "secretsmanager:*", "elasticfilesystem:*",
+          "sagemaker:*",
           "servicediscovery:*", "route53:*"
         ]
         Resource = "*"


### PR DESCRIPTION
- Added SageMaker permissions to the IAM role policy, ensuring necessary access for deployment tasks.
- Updated the deploy workflow to include a new variable for the champion S3 URI, facilitating model storage in S3.